### PR TITLE
Made the CloseCommand to be non-active 

### DIFF
--- a/Svg2Gcode/Svg/Paths/CloseCommand.cs
+++ b/Svg2Gcode/Svg/Paths/CloseCommand.cs
@@ -6,7 +6,7 @@ namespace Svg2Gcode.Svg.Paths
     {
         public override IEnumerable<(bool, Path2D)> GetPaths(Vector2D pathStart, Vector2D commandStart)
         {
-            yield return (true, new Path2D(commandStart, pathStart));
+            yield return (false, new Path2D(commandStart, pathStart));
         }
     }
 }


### PR DESCRIPTION
This fixes an issue where a rect path would include a superfluous point.