### PR TITLE
Fixes an issue with missing arguments 

### DIFF
--- a/Svg2Gcode/Svg/Paths/PathShapeParser.cs
+++ b/Svg2Gcode/Svg/Paths/PathShapeParser.cs
@@ -39,6 +39,10 @@ namespace Svg2Gcode.Svg.Paths
                 skipWhiteSpace = false;
                 if (char.IsLetter(commandKey) && commandKey != 'e') // new command
                 {
+                    var arg = builder.ToString();
+                    if (!string.IsNullOrEmpty(arg))
+                        arguments.Add(arg);
+
                     if (i > 0) // process the previous command
                     {
                         ICommandParser parser = getParser(previousCommandKey);
@@ -47,6 +51,7 @@ namespace Svg2Gcode.Svg.Paths
 
                     previousCommandKey = commandKey;
                     arguments.Clear();
+                    builder.Clear();
                     skipWhiteSpace = true;
                 }
                 else if (commandKey == ' ' || commandKey == ',')


### PR DESCRIPTION
The svg spec seems loose when it comes to the use of spaces and commas. it seems to be valid to have a command like 

    M34.4 33.0L10.0 11.2

in this case the parser ignored the second argument for M. this commit fixes this situation.